### PR TITLE
Support ipv6_address_preferred_lease_time for vpc dhcp options set

### DIFF
--- a/modules/vpc/dhcp-options.tf
+++ b/modules/vpc/dhcp-options.tf
@@ -21,10 +21,11 @@ resource "aws_vpc_dhcp_options" "this" {
     ? var.dhcp_options.domain_name
     : local.default_dhcp_options_domain_name
   )
-  domain_name_servers  = var.dhcp_options.domain_name_servers
-  ntp_servers          = var.dhcp_options.ntp_servers
-  netbios_name_servers = var.dhcp_options.netbios_name_servers
-  netbios_node_type    = var.dhcp_options.netbios_node_type
+  domain_name_servers               = var.dhcp_options.domain_name_servers
+  ipv6_address_preferred_lease_time = var.dhcp_options.ipv6_address_preferred_lease_time
+  ntp_servers                       = var.dhcp_options.ntp_servers
+  netbios_name_servers              = var.dhcp_options.netbios_name_servers
+  netbios_node_type                 = var.dhcp_options.netbios_node_type
 
   tags = merge(
     {

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -215,6 +215,7 @@ output "dhcp_options" {
 
     `domain_name` - The suffix domain name to use by default when resolving non Fully Qualified Domain Names.
     `domain_name_servers` - A list of name servers to configure in `/etc/resolv.conf`.
+    `ipv6_address_preferred_lease_time` - A value for how frequently a running instance with an IPv6 assigned to it goes through DHCPv6 lease renewal.
     `netbios_name_servers` - A list of NetBIOS name servers.
     `netbios_node_type` - The NetBIOS node type (1, 2, 4, or 8).
     `ntp_servers` - A list of NTP servers to configure.
@@ -225,11 +226,12 @@ output "dhcp_options" {
       arn   = one(aws_vpc_dhcp_options.this[*].arn)
       owner = one(aws_vpc_dhcp_options.this[*].owner_id)
 
-      domain_name          = one(aws_vpc_dhcp_options.this[*].domain_name)
-      domain_name_servers  = one(aws_vpc_dhcp_options.this[*].domain_name_servers)
-      netbios_name_servers = one(aws_vpc_dhcp_options.this[*].netbios_name_servers)
-      netbios_node_type    = one(aws_vpc_dhcp_options.this[*].netbios_node_type)
-      ntp_servers          = one(aws_vpc_dhcp_options.this[*].ntp_servers)
+      domain_name                       = one(aws_vpc_dhcp_options.this[*].domain_name)
+      domain_name_servers               = one(aws_vpc_dhcp_options.this[*].domain_name_servers)
+      ipv6_address_preferred_lease_time = one(aws_vpc_dhcp_options.this[*].ipv6_address_preferred_lease_time)
+      netbios_name_servers              = one(aws_vpc_dhcp_options.this[*].netbios_name_servers)
+      netbios_node_type                 = one(aws_vpc_dhcp_options.this[*].netbios_node_type)
+      ntp_servers                       = one(aws_vpc_dhcp_options.this[*].ntp_servers)
     }
     : null
   )

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -258,18 +258,20 @@ variable "dhcp_options" {
     (Optional) `name` - The name of the DHCP option set. Defaults to same name of the VPC.
     (Optional) `domain_name` - The suffix domain name to use by default when resolving non Fully Qualified Domain Names. In other words, this is what ends up being the search value in the `/etc/resolv.conf` file. If you're using `AmazonProvidedDNS` in `us-east-1`, specify `ec2.internal`. If you're using `AmazonProvidedDNS` in another Region, specify `{region}.compute.internal`.
     (Optional) `domain_name_servers` - A list of name servers to configure in `/etc/resolv.conf`. The IP addresses of up to four domain name servers, or `AmazonProvidedDNS`. If you want to use the default AWS nameservers you should set this to `AmazonProvidedDNS`. Defaults to `["AmazonProvidedDNS"]`.
+    (Optional) `ipv6_address_preferred_lease_time` - How frequently, in seconds, a running instance with an IPv6 assigned to it goes through DHCPv6 lease renewal. Acceptable values are between 140 and 2147483647 (approximately 68 years). Defaults to `140` seconds. If you use long-term addressing for EC2 instances, you can increase the lease time and avoid frequent lease renewal requests. Lease renewal typically occurs when half of the lease time has elapsed.
     (Optional) `netbios_name_servers` - A list of NetBIOS name servers. The IP addresses of up to four NetBIOS name servers.
     (Optional) `netbios_node_type` - The NetBIOS node type (1, 2, 4, or 8). AWS recommends to specify 2 since broadcast and multicast are not supported in their network. For more information about these node types, see RFC 2132. Defaults to `2`.
     (Optional) `ntp_servers` - A list of NTP servers to configure. The IP addresses of up to four Network Time Protocol (NTP) servers.
   EOF
   type = object({
-    enabled              = optional(bool, false)
-    name                 = optional(string)
-    domain_name          = optional(string)
-    domain_name_servers  = optional(list(string), ["AmazonProvidedDNS"])
-    netbios_name_servers = optional(list(string), [])
-    netbios_node_type    = optional(number, 2)
-    ntp_servers          = optional(list(string), [])
+    enabled                           = optional(bool, false)
+    name                              = optional(string)
+    domain_name                       = optional(string)
+    domain_name_servers               = optional(list(string), ["AmazonProvidedDNS"])
+    ipv6_address_preferred_lease_time = optional(number, 140)
+    netbios_name_servers              = optional(list(string), [])
+    netbios_node_type                 = optional(number, 2)
+    ntp_servers                       = optional(list(string), [])
   })
   default  = {}
   nullable = false

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.3"
+      version = ">= 5.46"
     }
   }
 }


### PR DESCRIPTION
### :wave: Background
<!-- Please explain the background or motivation for this change. -->

- Support ipv6_address_preferred_lease_time for vpc dhcp options set