### PR TITLE
chore(deps): align tedilabs child module version constraints with latest releases

### DIFF
--- a/examples/nat-gateway-private-secondary-ip-addresses/main.tf
+++ b/examples/nat-gateway-private-secondary-ip-addresses/main.tf
@@ -21,7 +21,7 @@ data "aws_subnets" "default" {
 module "nat_gateway" {
   source = "../../modules/nat-gateway"
   # source  = "tedilabs/network/aws//modules/nat-gateway"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name       = "test-count"
   is_private = true
@@ -43,7 +43,7 @@ module "nat_gateway" {
 module "nat_gateway_2" {
   source = "../../modules/nat-gateway"
   # source  = "tedilabs/network/aws//modules/nat-gateway"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name       = "test-assingments"
   is_private = true

--- a/examples/nat-gateway-private/main.tf
+++ b/examples/nat-gateway-private/main.tf
@@ -21,7 +21,7 @@ data "aws_subnets" "default" {
 module "nat_gateway" {
   source = "../../modules/nat-gateway"
   # source  = "tedilabs/network/aws//modules/nat-gateway"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name       = "test/az1"
   is_private = true

--- a/examples/nat-gateway-public/main.tf
+++ b/examples/nat-gateway-public/main.tf
@@ -20,7 +20,7 @@ data "aws_subnets" "default" {
 
 module "elastic_ip" {
   source  = "tedilabs/ipam/aws//modules/elastic-ip"
-  version = "~> 0.3.0"
+  version = "~> 0.4.0"
 
   name = "nat-gw-public"
   type = "AMAZON"
@@ -38,7 +38,7 @@ module "elastic_ip" {
 module "nat_gateway" {
   source = "../../modules/nat-gateway"
   # source  = "tedilabs/network/aws//modules/nat-gateway"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name       = "test/az1"
   is_private = false

--- a/examples/security-group-simple/main.tf
+++ b/examples/security-group-simple/main.tf
@@ -13,8 +13,8 @@ data "aws_vpc" "default" {
 
 module "security_group" {
   source = "../../modules/security-group"
-  # source  = "tedilabs/ipam/aws//modules/security-group"
-  # version = "~> 0.30.0"
+  # source  = "tedilabs/network/aws//modules/security-group"
+  # version = "~> 1.2.0"
 
   vpc_id = data.aws_vpc.default.id
 

--- a/examples/security-group-with-ipv4-cidrs/main.tf
+++ b/examples/security-group-with-ipv4-cidrs/main.tf
@@ -13,8 +13,8 @@ data "aws_vpc" "default" {
 
 module "security_group" {
   source = "../../modules/security-group"
-  # source  = "tedilabs/ipam/aws//modules/security-group"
-  # version = "~> 0.30.0"
+  # source  = "tedilabs/network/aws//modules/security-group"
+  # version = "~> 1.2.0"
 
   vpc_id = data.aws_vpc.default.id
 

--- a/examples/vpc-full/main.tf
+++ b/examples/vpc-full/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "vpc" {
   source = "../../modules/vpc"
   # source  = "tedilabs/network/aws//modules/vpc"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name = "test"
   ipv4_cidrs = [

--- a/examples/vpc-full/nacls.tf
+++ b/examples/vpc-full/nacls.tf
@@ -5,7 +5,7 @@
 module "private_network_acl" {
   source = "../../modules/nacl"
   # source  = "tedilabs/network/aws//modules/nacl"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name    = "test-private"
   vpc_id  = module.vpc.id
@@ -34,7 +34,7 @@ module "private_network_acl" {
 module "public_network_acl" {
   source = "../../modules/nacl"
   # source  = "tedilabs/network/aws//modules/nacl"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name    = "test-public"
   vpc_id  = module.vpc.id

--- a/examples/vpc-full/nat-gateways.tf
+++ b/examples/vpc-full/nat-gateways.tf
@@ -4,7 +4,7 @@
 
 module "elastic_ip" {
   source  = "tedilabs/ipam/aws//modules/elastic-ip"
-  version = "~> 0.3.0"
+  version = "~> 0.4.0"
 
   name = "nat-gw-test-public/az2"
   type = "AMAZON"
@@ -22,7 +22,7 @@ module "elastic_ip" {
 module "public_nat_gateway" {
   source = "../../modules/nat-gateway"
   # source  = "tedilabs/network/aws//modules/nat-gateway"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name       = "test-public/az2"
   is_private = false
@@ -47,7 +47,7 @@ module "public_nat_gateway" {
 module "private_nat_gateway" {
   source = "../../modules/nat-gateway"
   # source  = "tedilabs/network/aws//modules/nat-gateway"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name       = "test-private/az2"
   is_private = true

--- a/examples/vpc-full/route-tables.tf
+++ b/examples/vpc-full/route-tables.tf
@@ -5,7 +5,7 @@
 module "private_route_table" {
   source = "../../modules/route-table"
   # source  = "tedilabs/network/aws//modules/route-table"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name     = "test-private"
   vpc_id   = module.vpc.id
@@ -38,7 +38,7 @@ module "private_route_table" {
 module "public_route_table" {
   source = "../../modules/route-table"
   # source  = "tedilabs/network/aws//modules/route-table"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name     = "test-public"
   vpc_id   = module.vpc.id

--- a/examples/vpc-full/subnet-groups.tf
+++ b/examples/vpc-full/subnet-groups.tf
@@ -5,7 +5,7 @@
 module "private_subnet_group" {
   source = "../../modules/subnet-group"
   # source  = "tedilabs/network/aws//modules/subnet-group"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name = "test-private"
 
@@ -102,7 +102,7 @@ module "private_subnet_group" {
 module "public_subnet_group" {
   source = "../../modules/subnet-group"
   # source  = "tedilabs/network/aws//modules/subnet-group"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name = "test-public"
 

--- a/examples/vpc-ipv4-secondary-cidrs/main.tf
+++ b/examples/vpc-ipv4-secondary-cidrs/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "vpc" {
   source = "../../modules/vpc"
   # source  = "tedilabs/network/aws//modules/vpc"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name = "test"
   ipv4_cidrs = [

--- a/examples/vpc-ipv6-cidrs/main.tf
+++ b/examples/vpc-ipv6-cidrs/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "vpc" {
   source = "../../modules/vpc"
   # source  = "tedilabs/network/aws//modules/vpc"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name = "test"
   ipv4_cidrs = [

--- a/examples/vpc-simple/main.tf
+++ b/examples/vpc-simple/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "vpc" {
   source = "../../modules/vpc"
   # source  = "tedilabs/network/aws//modules/vpc"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name = "test"
   ipv4_cidrs = [

--- a/examples/vpc-with-ipam/ipam.tf
+++ b/examples/vpc-with-ipam/ipam.tf
@@ -11,7 +11,7 @@ locals {
 
 module "ipam" {
   source  = "tedilabs/ipam/aws//modules/ipam"
-  version = "~> 0.1.0"
+  version = "~> 0.4.0"
 
   name        = "test"
   description = "Managed by Terraform."

--- a/examples/vpc-with-ipam/main.tf
+++ b/examples/vpc-with-ipam/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "vpc" {
   source = "../../modules/vpc"
   # source  = "tedilabs/network/aws//modules/vpc"
-  # version = "~> 0.2.0"
+  # version = "~> 1.2.0"
 
   name = "test"
   ipv4_cidrs = [

--- a/modules/security-group/ram-share.tf
+++ b/modules/security-group/ram-share.tf
@@ -13,7 +13,7 @@ locals {
 
 module "share" {
   source  = "tedilabs/organization/aws//modules/ram-share"
-  version = "~> 0.5.0"
+  version = "~> 0.7.0"
 
   for_each = {
     for share in var.shares :

--- a/modules/subnet-group/ram-share.tf
+++ b/modules/subnet-group/ram-share.tf
@@ -13,7 +13,7 @@ locals {
 
 module "share" {
   source  = "tedilabs/organization/aws//modules/ram-share"
-  version = "~> 0.5.0"
+  version = "~> 0.7.0"
 
   for_each = {
     for share in var.shares :


### PR DESCRIPTION
## What & why

Version constraints on sibling `tedilabs/*` child modules had drifted well behind those modules' latest releases — `ipam/ipam` was still pinned three minors back at `~> 0.1.0`, and the commented registry hints in `examples/` still advertised `~> 0.2.0` while this repo is on `v1.2.3`. This realigns every constraint to the house `~> MAJOR.MINOR.0` minor-floor convention against the current latest release of each target.

It also fixes a copy-paste namespace typo: two `examples/` files advertised `modules/security-group` under the `tedilabs/ipam` namespace. That module has lived in **this** repo since 2021 and has never existed in `terraform-aws-ipam` (see the interface section below), so both the source and the version were corrected.

## Changed constraints

### Active module blocks

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `tedilabs/ipam/aws//modules/elastic-ip` | `examples/nat-gateway-public/main.tf:23` | `~> 0.3.0` | `~> 0.4.0` | `v0.4.1` |
| `tedilabs/ipam/aws//modules/elastic-ip` | `examples/vpc-full/nat-gateways.tf:7` | `~> 0.3.0` | `~> 0.4.0` | `v0.4.1` |
| `tedilabs/ipam/aws//modules/ipam` | `examples/vpc-with-ipam/ipam.tf:14` | `~> 0.1.0` | `~> 0.4.0` | `v0.4.1` |
| `tedilabs/organization/aws//modules/ram-share` | `modules/security-group/ram-share.tf:16` | `~> 0.5.0` | `~> 0.7.0` | `v0.7.5` |
| `tedilabs/organization/aws//modules/ram-share` | `modules/subnet-group/ram-share.tf:16` | `~> 0.5.0` | `~> 0.7.0` | `v0.7.5` |

### Example docs (commented registry alternatives)

The active `source` in every `examples/` root is a local `../../modules/x` path; the lines below are the commented-out registry equivalents shown as documentation.

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `tedilabs/network/aws//modules/security-group` | `examples/security-group-simple/main.tf:16-17` | `tedilabs/ipam/…` @ `~> 0.30.0` | `tedilabs/network/…` @ `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/security-group` | `examples/security-group-with-ipv4-cidrs/main.tf:16-17` | `tedilabs/ipam/…` @ `~> 0.30.0` | `tedilabs/network/…` @ `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/vpc` | `examples/vpc-simple/main.tf:13` | `~> 0.2.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/vpc` | `examples/vpc-full/main.tf:13` | `~> 0.2.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/vpc` | `examples/vpc-ipv4-secondary-cidrs/main.tf:13` | `~> 0.2.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/vpc` | `examples/vpc-ipv6-cidrs/main.tf:13` | `~> 0.2.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/vpc` | `examples/vpc-with-ipam/main.tf:13` | `~> 0.2.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/subnet-group` | `examples/vpc-full/subnet-groups.tf:8, :105` | `~> 0.2.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/route-table` | `examples/vpc-full/route-tables.tf:8, :41` | `~> 0.2.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/nacl` | `examples/vpc-full/nacls.tf:8, :37` | `~> 0.2.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/nat-gateway` | `examples/vpc-full/nat-gateways.tf:25, :50` | `~> 0.2.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/nat-gateway` | `examples/nat-gateway-public/main.tf:41` | `~> 0.2.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/nat-gateway` | `examples/nat-gateway-private/main.tf:24` | `~> 0.2.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/nat-gateway` | `examples/nat-gateway-private-secondary-ip-addresses/main.tf:24, :46` | `~> 0.2.0` | `~> 1.2.0` | `v1.2.3` |

Totals: 5 active constraint bumps, 19 commented-line updates (of which 2 also had the source namespace corrected).

## Interface changes between the old and new versions

### `tedilabs/organization/aws//modules/ram-share` — v0.5.6 → v0.7.5

Compare: https://github.com/tedilabs/terraform-aws-organization/compare/v0.5.6...v0.7.5

**Verdict: no interface change — and in fact no change at all.** The `modules/ram-share` directory is byte-identical between the two tags: the git tree object for the path is the same hash (`63ef8ac`), `git diff v0.5.6..v0.7.5 -- modules/ram-share/` is empty, and no commit between the tags touched the path. No variables added, removed, renamed or retyped; no output changes. `versions.tf` is identical too, so the `>= 1.12` / `hashicorp/aws >= 6.12` floors are not *new* — they were already in force at v0.5.6. This is a pure constraint bump with zero calling-code impact.

### `tedilabs/ipam/aws//modules/elastic-ip` — v0.3.2 → v0.4.1

Compare: https://github.com/tedilabs/terraform-aws-ipam/compare/v0.3.2...v0.4.1

**Verdict: breaking interface, but no calling code in this repo is affected.**

- **Renamed:** `ipam_pool` → `pool` (same object shape `{ id, address = optional(string) }`). A new cross-variable validation now requires `pool` whenever `type != "AMAZON"`, and forbids it when `type == "AMAZON"`.
- **Removed / collapsed:** the three flat variables `resource_group_enabled`, `resource_group_name`, `resource_group_description` became a single `resource_group` object with all-`optional()` attributes carrying the old defaults.
- **Added (all optional):** `region`, `reverse_domain_name`. The `type` enum widened from `AMAZON | IPAM_POOL | OUTPOST` to also accept `BYOIP`.
- **Removed output:** `scope` (was `upper(aws_eip.this.domain)`, always `"VPC"` in practice). Added outputs: `region`, `pool`, `private_domain`, `private_ip`, `public_domain`, `reverse_domain_name`, `resource_group`.
- **Version floors raised:** Terraform `>= 1.6` → `>= 1.12`; `hashicorp/aws` `>= 5.3` → `>= 6.12` (major provider generation bump).

**Why no code change was needed here:** both call sites (`examples/nat-gateway-public`, `examples/vpc-full`) use `type = "AMAZON"` and pass only `name`, `type` and `tags`. They never set `ipam_pool` (so the rename is a no-op, and the new "must not be provided when `AMAZON`" arm of the validation is satisfied) and never set any `resource_group_*` variable. Neither references the removed `scope` output — `examples/nat-gateway-public/outputs.tf` exports the whole `module.elastic_ip` object, and `examples/vpc-full/outputs.tf` does not reference the module at all.

### `tedilabs/ipam/aws//modules/ipam` — v0.1.0 → v0.4.1

Compare: https://github.com/tedilabs/terraform-aws-ipam/compare/v0.1.0...v0.4.1

**Verdict: breaking interface, but no calling code in this repo is affected.**

- **Removed / collapsed:** same refactor as `elastic-ip` — `resource_group_enabled` / `resource_group_name` / `resource_group_description` → one `resource_group` object with all-`optional()` attributes. This is the only mandatory HCL change the module's own argument surface imposes.
- **Added (all optional, defaults preserve prior behaviour):** `region`, `tier` (`FREE` | `ADVANCED`), `metered_account` (`IPAM_OWNER` | `RESOURCE_OWNER`), `private_gua_enabled`, `resource_group`.
- **Not removed:** `cascade_deletion_enabled` still exists at v0.4.1 with the same `bool` type and `default = true` — it merely moved position in `variables.tf`, which makes the raw diff read as if `private_gua_enabled` replaced it.
- **No object-internal changes:** `additional_private_scopes` and `additional_resource_discovery_associations` are byte-identical at both tags — no list→map conversion, no newly-required attribute.
- **Outputs:** none removed, none renamed. Added: `region`, `tier`, `metered_account`, `private_gua_enabled`, `resource_group`. Inside the existing `additional_private_scopes` output the `type` key now sources from the provider's renamed `aws_vpc_ipam_scope.type` attribute (was `.ipam_scope_type`) — the output's shape is unchanged.
- **Version floors raised:** Terraform `>= 1.3` → `>= 1.12`; `hashicorp/aws` `>= 4.58` → `>= 6.12` (two major provider generations).

**Why no code change was needed here:** `examples/vpc-with-ipam/ipam.tf` passes only `name`, `description`, `operating_regions` and `tags` — no `resource_group_*` variables and no `cascade_deletion_enabled`. Its consumers use `module.ipam.default_scopes[...]`, an output that is unchanged.

Note: the `ipam_pool = { … }` blocks in `examples/vpc-with-ipam/main.tf` were deliberately **not** renamed. Those belong to *this* repo's `modules/vpc` variables `ipv4_cidrs[].ipam_pool` / `ipv6_cidrs[].ipam_pool`, which are unrelated to the `elastic-ip` rename.

### `hashicorp/aws` provider floor

Both `ipam/*` bumps raise the floor to `aws >= 6.12` and Terraform `>= 1.12`. All three affected example roots already declare `required_version = "~> 1.12"` and `aws ~> 6.0` in their own `versions.tf`, so no `versions.tf` edits were needed. Resolution was confirmed live: `terraform init` reported `Finding hashicorp/aws versions matching ">= 6.0.0, ~> 6.0, >= 6.12.0"` and settled on v6.58.0.

### `modules/security-group` namespace typo

Not a module relocation — a copy-paste error in the commented hint. `terraform-aws-ipam` has never contained `modules/security-group` at any tag or any commit (`git log --all -- modules/security-group` is empty there; its module set is only `elastic-ip`, `ipam`, `ipam-resource-discovery`, `managed-prefix-list`, `prefix-list`). `modules/security-group` has lived in this repo since its first commit, `2478343 Add security-group module`, dated 2021-02-15. The stale `~> 0.30.0` pin is itself internally consistent with *this* repo's tag series, which corroborates that the middle segment was simply wrong. Sibling examples in the same directory already use the correct `tedilabs/network/...` namespace. Nothing was broken at runtime, since both files' active `source` is the local `../../modules/security-group`.

## Verification

- `terraform fmt -recursive -check .` — passes (alignment on `=` preserved; commented lines kept their `# ` prefix and indentation).
- `terraform init -backend=false -upgrade && terraform validate` in every directory touched by an **active** constraint change, plus both example roots whose commented source was corrected:

| Directory | `init` | `validate` |
|---|---|---|
| `modules/security-group` | resolved `tedilabs/organization/aws 0.7.5` | **Success** |
| `modules/subnet-group` | resolved `tedilabs/organization/aws 0.7.5` | **Success** |
| `examples/nat-gateway-public` | resolved `tedilabs/ipam/aws 0.4.1` | **Success** |
| `examples/vpc-with-ipam` | resolved `tedilabs/ipam/aws 0.4.1` | **Success** (with a pre-existing deprecation warning: `data.aws_region.this.name` — "name is deprecated. Use region instead.") |
| `examples/security-group-simple` | — | **Success** |
| `examples/security-group-with-ipv4-cidrs` | — | **Success** |
| `examples/vpc-full` | resolved `tedilabs/ipam/aws 0.4.1` | **fails on a pre-existing, unrelated error** — see below |

`examples/vpc-full` `init` succeeded and the new `~> 0.4.0` constraint resolved to `tedilabs/ipam/aws 0.4.1` cleanly, but `validate` fails on:

```
Error: Invalid value for input variable
  on main.tf line 49, in module "vpc":
  49:   default_network_acl = {
The given value is not suitable for module.vpc.var.default_network_acl
declared at ../../modules/vpc/variables.tf:143,1-31: attribute
"ingress_rules": map of object required.
```

This is a latent bug on `main` that predates this PR and is untouched by it: the example passes `default_network_acl.ingress_rules` as a **list** while `modules/vpc/variables.tf` declares it as `map(object(...))`. The only change this PR makes to `examples/vpc-full/main.tf` is a commented `# version` line. It is left unfixed here to keep this PR scoped to dependency constraints, and is worth a separate issue.

What was **not** verified: no `terraform plan` or `apply` was run anywhere, so nothing was checked against real AWS. In particular, the `elastic-ip` upgrade carries a state-level migration note that only a plan can surface — for `type = "IPAM_POOL"`, v0.3.2 set `public_ipv4_pool = var.ipam_pool.id` whereas v0.4.1 sets `ipam_pool_id = var.pool.id`, which may show as an EIP **replacement** rather than an in-place update. Neither call site in this repo uses `IPAM_POOL` (both are `AMAZON`), but downstream consumers of these modules should review their plans. Similarly, the `ipam` upgrade now sets `tier` / `metered_account` explicitly and adds a `Name` tag to `aws_vpc_ipam_resource_discovery_association`, so expect in-place tag updates there.

All `.terraform/` directories and `.terraform.lock.hcl` files created during verification were removed; `git status --porcelain` was confirmed clean before committing.

## Supersedes

- **#83** — `chore(deps): update tedilabs/organization/aws requirement from ~> 0.5.0 to ~> 0.6.4 in /modules/security-group`
- **#84** — `chore(deps): update tedilabs/organization/aws requirement from ~> 0.5.0 to ~> 0.6.4 in /modules/subnet-group`

These two dependabot PRs cover the same two `tedilabs/organization/aws` constraints that this PR changes, but they pin `~> 0.6.4` — an exact-patch pin against a version that is itself already behind (latest is `v0.7.5`) — instead of the house minor-floor convention `~> 0.7.0`. They also do not cover the `ipam/*` constraints or any of the commented registry hints in `examples/`. Leaving them open for the maintainer to close; this PR does not close them.
