### PR TITLE
fix(examples): pass default_network_acl ingress rules as a keyed map in vpc-full

### DIFF
--- a/examples/vpc-full/main.tf
+++ b/examples/vpc-full/main.tf
@@ -48,24 +48,22 @@ module "vpc" {
   ## Defaults
   default_network_acl = {
     name = "test-default"
-    ingress_rules = [
-      {
-        priority  = 200
+    ingress_rules = {
+      200 = {
         action    = "ALLOW"
         protocol  = "tcp"
         from_port = 443
         to_port   = 443
         ipv4_cidr = "0.0.0.0/0"
-      },
-      {
-        priority  = 201
+      }
+      201 = {
         action    = "ALLOW"
         protocol  = "tcp"
         from_port = 443
         to_port   = 443
         ipv6_cidr = "::/0"
-      },
-    ]
+      }
+    }
   }
   default_security_group = {
     name = "test-default"


### PR DESCRIPTION
## What & why

`examples/vpc-full` did not pass `terraform validate`: it passed `default_network_acl.ingress_rules`
as a **list of objects with a `priority` attribute**, but `modules/vpc/variables.tf` declares that
attribute as a **`map(object(...))` keyed by the NACL rule number**, with no `priority` attribute in
the object. This PR rewrites that one call to match the module's current interface. Every other
`modules/*` and `examples/*` directory in the repo was audited (`fmt` / `init -backend=false` /
`validate`) and was already green, so nothing else is touched.

## Validation matrix

`terraform fmt -check -recursive .`, `terraform init -backend=false`, `terraform validate` run in
each directory with a warm provider cache. Terraform v1.15.6, hashicorp/aws v6.58.0,
hashicorp/assert v0.16.0.

| Directory | fmt (before → after) | init (before → after) | validate (before → after) |
|---|---|---|---|
| `modules/nacl` | OK → OK | OK → OK | OK → OK |
| `modules/nat-gateway` | OK → OK | OK → OK | OK → OK |
| `modules/route-table` | OK → OK | OK → OK | OK → OK |
| `modules/security-group` | OK → OK | OK → OK | OK → OK |
| `modules/subnet-group` | OK → OK | OK → OK | OK → OK |
| `modules/vpc` | OK → OK | OK → OK | OK → OK |
| `examples/nat-gateway-private` | OK → OK | OK → OK | OK → OK |
| `examples/nat-gateway-private-secondary-ip-addresses` | OK → OK | OK → OK | OK → OK |
| `examples/nat-gateway-public` | OK → OK | OK → OK | OK → OK |
| `examples/security-group-simple` | OK → OK | OK → OK | OK → OK |
| `examples/security-group-with-ipv4-cidrs` | OK → OK | OK → OK | OK → OK |
| `examples/vpc-full` | OK → OK | OK → OK | **FAIL → OK** |
| `examples/vpc-ipv4-secondary-cidrs` | OK → OK | OK → OK | OK → OK |
| `examples/vpc-ipv6-cidrs` | OK → OK | OK → OK | OK → OK |
| `examples/vpc-simple` | OK → OK | OK → OK | OK → OK |
| `examples/vpc-with-ipam` | OK → OK | OK → OK | OK → OK |

`terraform fmt -recursive -check .` at the repo root is clean before and after.

## Changes

### `examples/vpc-full/main.tf` — `default_network_acl.ingress_rules` must be a map keyed by rule number

Error before the change:

```
Error: Invalid value for input variable

  on main.tf line 49, in module "vpc":
  49:   default_network_acl = {
  ...
The given value is not suitable for module.vpc.var.default_network_acl
declared at ../../modules/vpc/variables.tf:143,1-31: attribute
"ingress_rules": map of object required.
```

`modules/vpc/variables.tf:143` declares:

```hcl
    ingress_rules = optional(map(object({
      action    = string
      protocol  = string
      from_port = optional(number)
      to_port   = optional(number)
      ipv4_cidr = optional(string)
      ipv6_cidr = optional(string)
      icmp_type = optional(number, 0)
      icmp_code = optional(number, 0)
    })), {})
```

and `modules/vpc/defaults.tf:45-47` uses the map key as the rule number
(`rule_no = tonumber(ingress.key)`). There is no `priority` attribute on the object.

Before:

```hcl
  default_network_acl = {
    name = "test-default"
    ingress_rules = [
      {
        priority  = 200
        action    = "ALLOW"
        protocol  = "tcp"
        from_port = 443
        to_port   = 443
        ipv4_cidr = "0.0.0.0/0"
      },
      {
        priority  = 201
        action    = "ALLOW"
        protocol  = "tcp"
        from_port = 443
        to_port   = 443
        ipv6_cidr = "::/0"
      },
    ]
  }
```

After — the former `priority` values become the map keys, which is exactly what the module does with
them, and matches how the sibling `examples/vpc-full/nacls.tf` keys its `ingress_rules` /
`egress_rules` maps:

```hcl
  default_network_acl = {
    name = "test-default"
    ingress_rules = {
      200 = {
        action    = "ALLOW"
        protocol  = "tcp"
        from_port = 443
        to_port   = 443
        ipv4_cidr = "0.0.0.0/0"
      }
      201 = {
        action    = "ALLOW"
        protocol  = "tcp"
        from_port = 443
        to_port   = 443
        ipv6_cidr = "::/0"
      }
    }
  }
```

The rendered NACL is unchanged: rule 200 allows TCP/443 from `0.0.0.0/0`, rule 201 allows TCP/443
from `::/0`.

Note `default_security_group.ingress_rules` / `egress_rules` in the same block are declared as
`set(object(...))`, so those stay as lists — they were already correct.

## Still failing

Nothing. All 6 module directories and all 10 example directories pass `fmt`, `init -backend=false`
and `validate` after this change.

## Not fixed — documentation defect worth a follow-up

The variable descriptions for the NACL rule maps still document a `priority` attribute that the type
does not have, which is what the stale example encoded:

- `modules/vpc/variables.tf:148` and `:158` — ``(Required) `priority` - The rule priority. The rule number. Used for ordering.``
- `modules/nacl/variables.tf:30` and `:65` — same line

The same sentence already says "Use the key of map as the rule number (priority)", so these four
lines are simply leftovers from an older list-based interface. They are left alone here to keep this
PR to the validation fix (changing them also regenerates the two module `README.md` files via
`terraform-docs`). Worth a small docs PR.

## Verification

- Audited every `modules/*` and `examples/*` directory with `terraform fmt -check -recursive .`,
  `terraform init -backend=false`, `terraform validate`.
- Captured the failing `validate` output for `examples/vpc-full` at `origin/main` and re-ran it after
  the change (`Success! The configuration is valid.`).
- `terraform plan` / `apply` were **not** run — no AWS credentials were used, so nothing here proves
  the configuration applies cleanly, only that it type-checks.
- No `*.md` file in this repo contains a module example block (`grep -rn 'source *=' --include='*.md'`
  returns nothing), so there were no README examples to re-verify.
