### PR TITLE
fix(examples): replace deprecated aws_region name attribute with region

### DIFF
--- a/examples/vpc-with-ipam/ipam.tf
+++ b/examples/vpc-with-ipam/ipam.tf
@@ -1,7 +1,7 @@
 data "aws_region" "this" {}
 
 locals {
-  region = data.aws_region.this.name
+  region = data.aws_region.this.region
 }
 
 


### PR DESCRIPTION
## What & why

The `name` attribute of the `aws_region` data source is **deprecated on the AWS provider v6 line**
in favour of `region`. `terraform validate` reported it on every affected root:

```
Warning: Argument is deprecated
  with data.aws_region.this,
  name is deprecated. Use region instead.
```

This replaces `data.aws_region.<x>.name` with `.region`.

## Safety

`.region` exists from provider v6.0 onward, so this is only safe where the declared floor already
requires v6. Verified per site before editing (see the table below) — no version constraint was
changed by this PR.

## Verification

`terraform init -backend=false` then `terraform validate` in each affected directory. The acceptance
test is a **warning-free** validate, which is real evidence here (unlike the silently-dropped
attribute class, which validate cannot see).

| Directory | Before | After |
|---|---|---|
| `examples/vpc-with-ipam` | 1 deprecation warning | **OK, 0 warnings** |

That root pins `aws = "~> 6.0"`.

`terraform fmt -check` passes. No `terraform plan`/`apply` was run.

## Scope

This was found by an org-wide grep for `aws_region\.[a-z_]*\.name`, which turned up 9 occurrences
across 5 repos. Handled separately per repo so each stays reviewable:

- `terraform-aws-data` (3 sites), `terraform-aws-network` (1), `terraform-aws-messaging` (2) — all
  already on `aws ~> 6.0` / `>= 6.12`, fixed.
- `terraform-aws-observability/modules/cloudwatch-log-policy/policy.tf` — **deliberately not fixed.**
  That module declares `aws >= 4.22`, and `.region` does not exist before v6, so switching would
  silently narrow its declared support range. Its two example roots are also the last in the org still
  pinning `aws ~> 4.0`, so the module floor and both examples have to move together. Left for an
  owner decision.
- `terraform-aws-s3` (2 sites) — repository has no GitHub remote.
